### PR TITLE
Set tile priority to fix bug

### DIFF
--- a/lib/selection-counter-view.coffee
+++ b/lib/selection-counter-view.coffee
@@ -8,9 +8,9 @@ class SelectionCounterView extends HTMLDivElement
   attach: ->
     alignment = atom.config.get 'selection-counter.statusAlignment'
     if alignment == 'left'
-      @tile = @statusBar.addLeftTile(item: this)
+      @tile = @statusBar.addLeftTile(item: this, priority: 0)
     else
-      @tile = @statusBar.addRightTile(item: this)
+      @tile = @statusBar.addRightTile(item: this, priority: 0)
 
   handleEvents: ->
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>


### PR DESCRIPTION
I'm running Atom 1.21.2 and ran into the same issue as #5. This commit fixes #5 by adding the required priority value when adding the tile to the status bar.